### PR TITLE
Use the properties in <dependencyManagement> and <pluginManagement>

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@ Projects wishing to use pom-scijava as a parent project need to override the &lt
 		<imglib2.groupId>net.imglib2</imglib2.groupId>
 		<imglib2.version>2.0.0-beta-25</imglib2.version>
 		<imglib2-ij.version>2.0.0-beta-25</imglib2-ij.version>
+		<imglib2-scripting.version>2.0.0-beta-24</imglib2-scripting.version>
 
 		<!-- MiniMaven - https://github.com/imagej/minimaven -->
 		<minimaven.groupId>net.imagej</minimaven.groupId>
@@ -185,6 +186,11 @@ Projects wishing to use pom-scijava as a parent project need to override the &lt
 				<groupId>${imglib2.groupId}</groupId>
 				<artifactId>imglib2-ij</artifactId>
 				<version>${imglib2-ij.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>${imglib2.groupId}</groupId>
+				<artifactId>imglib2-scripting</artifactId>
+				<version>${imglib2-scripting.version}</version>
 			</dependency>
 
 			<!-- ImageJ - https://github.com/imagej/imagej -->


### PR DESCRIPTION
This allows us to omit the explicit versions of dependencies (but sadly,
not the groupIds) in POMs inheriting from pom-scijava.

Example:

```
...
<dependencies>
    <!-- The version is defined in pom-scijava -->
    <dependency>
        <groupId>${imagej.groupId}</groupId>
        <artifactId>ij-core</artifactId>
    </dependency>
</dependencies>
...
```

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
