### PR TITLE
Enforce SciJava annotation processing even in Eclipse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1188,6 +1188,33 @@ Projects wishing to use pom-scijava as a parent project need to override the &lt
 				</repository>
 			</distributionManagement>
 		</profile>
+
+		<!-- This profile helps Eclipse parse SciJava annotations of imported projects. -->
+		<profile>
+			<id>only-eclipse</id>
+			<activation>
+				<property>
+					<name>m2e.version</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.scijava</groupId>
+						<artifactId>scijava-maven-plugin</artifactId>
+						<version>${scijava-maven-plugin.version}</version>
+						<executions>
+							<execution>
+								<goals>
+									<goal>eclipse-helper</goal>
+								</goals>
+								<phase>process-classes</phase>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 </project>


### PR DESCRIPTION
With this topic branch merged, `pom-scijava`based Maven projects will be built properly even in Eclipse (which is slightly challenging due to Eclipse's ignoring of annotation processors).

This PR relies on https://github.com/scijava/scijava-maven-plugin/pull/2 (therefore, the latter PR should be merged, and `scijava-maven-plugin` version `0.2.0` released, first).
