### PR TITLE
Update jdom2 to v2.0.6.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@ Projects wishing to use pom-scijava as a parent project need to override the &lt
 		<jcommon.version>1.0.23</jcommon.version>
 
 		<!-- JDOM - http://www.jdom.org/ -->
-		<jdom2.version>2.0.5</jdom2.version>
+		<jdom2.version>2.0.6</jdom2.version>
 
 		<!-- Jetty - http://eclipse.org/jetty/ -->
 		<jetty.version>9.1.3.v20140225</jetty.version>


### PR DESCRIPTION
Currently, some of the tools that rely on JDom2 to import XML (e.g. TrackMate & MaMuT) generate an exception with JDom 2.0.5.

Example in MaMuT:

```
java.lang.ExceptionInInitializerError
	at org.jdom2.input.SAXBuilder.<init>(SAXBuilder.java:338)
	at org.jdom2.input.SAXBuilder.<init>(SAXBuilder.java:221)
	at fiji.plugin.trackmate.io.TmXmlReader.<init>(TmXmlReader.java:168)
	at fiji.plugin.mamut.io.MamutXmlReader.<init>(MamutXmlReader.java:33)
	at fiji.plugin.mamut.LoadMamutAnnotationPlugin.load(LoadMamutAnnotationPlugin.java:68)
	at fiji.plugin.mamut.LoadMamutAnnotationPlugin.run(LoadMamutAnnotationPlugin.java:61)
	at ij.IJ.runUserPlugIn(IJ.java:212)
	at ij.IJ.runPlugIn(IJ.java:176)
	at ij.Executer.runCommand(Executer.java:132)
	at ij.Executer.run(Executer.java:65)
	at java.lang.Thread.run(Thread.java:745)
Caused by: org.apache.xerces.xni.parser.XMLConfigurationException: http://apache.org/xml/features/allow-java-encodings
	at org.apache.xerces.impl.xs.XMLSchemaLoader.getFeature(Unknown Source)
	at org.apache.xerces.jaxp.validation.XMLSchemaFactory.propagateFeatures(Unknown Source)
	at org.apache.xerces.jaxp.validation.XMLSchemaFactory.newSchema(Unknown Source)
	at org.jdom2.input.sax.XMLReaders.<init>(XMLReaders.java:123)
	at org.jdom2.input.sax.XMLReaders.<clinit>(XMLReaders.java:95)
	... 11 more
```

Is is apparently linked to creating a SAX parser with no args, as in:
``final SAXBuilder sb = new SAXBuilder();``

The issue is referred here:
http://comments.gmane.org/gmane.comp.java.jdom.general/4070
where it is suggested to specify a specific parser.

However, updating JDom2 version to 2.0.6 fixes the problem and leave the parser choice to JDom2.

This PR updates JDom2 version shipped in SciJava project from v2.0.5 to v2.0.6.