### PR TITLE
POM: bump extra-enforcer-rules version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1277,7 +1277,7 @@ Projects wishing to use pom-scijava as a parent project need to override the &lt
 						<dependency>
 							<groupId>org.codehaus.mojo</groupId>
 							<artifactId>extra-enforcer-rules</artifactId>
-							<version>1.0-beta-3</version>
+							<version>1.0-beta-4</version>
 						</dependency>
 						<dependency>
 							<groupId>org.scijava</groupId>


### PR DESCRIPTION
An issue with a NPE has been fixed in 1.0-beta-4 when using M2E.