### PR TITLE
Bump Bio-Formats version to 5.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@ Projects wishing to use pom-scijava as a parent project need to override the &lt
 		<!-- Open Microscopy Environment - https://github.com/openmicroscopy -->
 
 		<!-- Bio-Formats - https://github.com/openmicroscopy/bioformats -->
-		<bio-formats.version>5.1.10</bio-formats.version>
+		<bio-formats.version>5.2.0</bio-formats.version>
 		<bio-formats_plugins.version>${bio-formats.version}</bio-formats_plugins.version>
 		<formats-api.version>${bio-formats.version}</formats-api.version>
 		<formats-bsd.version>${bio-formats.version}</formats-bsd.version>


### PR DESCRIPTION
Following Bio-Formats 5.2.0 release, this bumps the `bioformats.version` in the scijava pom as discussed in https://github.com/openmicroscopy/bioformats/pull/2482#discussion_r74788623