### PR TITLE
Bump Bio-Formats version to 5.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -539,7 +539,7 @@
 		<ome-xml.version>5.5.4</ome-xml.version>
 
 		<!-- Bio-Formats - https://github.com/openmicroscopy/bioformats -->
-		<bio-formats.version>5.7.1</bio-formats.version>
+		<bio-formats.version>5.7.2</bio-formats.version>
 		<bio-formats_plugins.version>${bio-formats.version}</bio-formats_plugins.version>
 		<formats-api.version>${bio-formats.version}</formats-api.version>
 		<formats-bsd.version>${bio-formats.version}</formats-bsd.version>


### PR DESCRIPTION
Bumping the Bio-Formats version to 5.7.2 following the latest release.
See http://forum.imagej.net/t/release-of-bio-formats-5-7-2/7999