### PR TITLE
Bump ome-common to 5.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -534,7 +534,7 @@
 		<!-- Open Microscopy Environment - https://github.com/openmicroscopy -->
 
 		<!-- OME Common Java - https://github.com/ome/ome-common-java -->
-		<ome-common.version>5.3.3</ome-common.version>
+		<ome-common.version>5.3.4</ome-common.version>
 
 		<!-- OME POI - https://github.com/ome/ome-poi -->
 		<ome-poi.version>5.3.1</ome-poi.version>


### PR DESCRIPTION
Changes released in `org.openmicroscopy:ome-common:5.3.3` caused TIFF writing failures when tested internally in Bio-Formats and got reverted in `org.openmicroscopy:ome-common:5.3.4` 

References:
- https://trello.com/c/OimiHAQY/175-profile-tiff-writing-on-windows
- https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=8441
- https://github.com/ome/ome-common-java/pull/21