### PR TITLE
Add jmh-core and jmh-generator-annprocess

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -761,6 +761,11 @@
 		<!-- JHDF5 - https://wiki-bsse.ethz.ch/label/JHDF5/hdf5 -->
 		<jhdf5.version>14.12.6</jhdf5.version>
 
+		<!-- JMH - http://openjdk.java.net/projects/code-tools/jmh/ -->
+		<jmh.version>1.19</jmh.version>
+		<jmh-core.version>${jmh.version}</jmh-core.version>
+		<jmh-generator-annprocess.version>${jmh.version}</jmh-generator-annprocess.version>
+
 		<!-- JMockit - https://jmockit.github.io/ -->
 		<jmockit.version>1.33</jmockit.version>
 
@@ -3246,6 +3251,21 @@
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
 				<version>${mockito-core.version}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<!-- JMH - http://openjdk.java.net/projects/code-tools/jmh/ -->
+			<dependency>
+				<groupId>org.openjdk.jmh</groupId>
+				<artifactId>jmh-core</artifactId>
+				<version>${jmh-core.version}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.openjdk.jmh</groupId>
+				<artifactId>jmh-generator-annprocess</artifactId>
+				<version>${jmh-generator-annprocess.version}</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
These artifacts are used in several components now, e.g. `imagej-legacy`, `imglib2`, `scijava-benchmarks`, `imagej-benchmarks`, and others.
