### PR TITLE
Add Code Formatter 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,13 @@
 		<license.licenseName>N/A</license.licenseName>
 		<license.copyrightOwners>N/A</license.copyrightOwners>
 
+		<!--
+		Set the coding-style property to define a coding style to be used in
+		your project.
+		Supported values are: imagej, imglib2 and scifio
+		-->
+		<coding-style>imagej</coding-style>
+
 		<!-- Managed dependency versions - SciJava component collection -->
 
 		<!--
@@ -3792,4 +3799,34 @@
 			</pluginRepositories>
 		</profile>
 	</profiles>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>net.revelc.code.formatter</groupId>
+					<artifactId>formatter-maven-plugin</artifactId>
+					<version>2.8.1</version>
+					<dependencies>
+						<dependency>
+							<groupId>org.scijava</groupId>
+							<artifactId>scijava-coding-style</artifactId>
+							<version>1.0.0-SNAPSHOT</version>
+						</dependency>
+					</dependencies>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		<plugins>
+			<!-- Code Formatter Plugin -->
+			<plugin>
+				<groupId>net.revelc.code.formatter</groupId>
+				<artifactId>formatter-maven-plugin</artifactId>
+				<configuration>
+					<configFile>eclipse-formatter-settings/${coding-style}-coding-style.xml</configFile>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3826,6 +3826,22 @@
 					<configFile>eclipse-formatter-settings/${coding-style}-coding-style.xml</configFile>
 				</configuration>
 			</plugin>
+			<!-- Organize Imports Plugin -->
+			<plugin>
+				<groupId>net.revelc.code</groupId>
+				<artifactId>impsort-maven-plugin</artifactId>
+				<version>1.2.0</version>
+				<configuration>
+					<groups>java.,javax.,com.,net.,org.</groups>
+					<staticGroups>java,*</staticGroups>
+					<removeUnused>true</removeUnused>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>none</phase>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
This PR configures a maven code format plugin in `pom-scijava`. A maven project that depends on `pom-scijava` can be formatted according to [ImageJ Coding Style](https://imagej.net/Coding_style#Eclipse_code_style_profiles) by simply calling:
```
$ mvn formatter:format
```
This will use the Eclipse coding style configuration files in this (not yet released) maven artifact:
https://github.com/scijava/scijava-coding-style

It can also be set up to use ImgLib2 or SCIFIO coding style by stetting by setting the maven property to "imglib2" or "scifio" ("imagej" is the default value):
```
<properties>
    <coding-style>imglib2</coding-style>
</properties>
```

Sorting of java imports is supported as well:
```
$ mvn impsort:sort
```

