### PR TITLE
Bump Bio-Formats version to 6.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -586,7 +586,7 @@
 		<ome-xml.version>6.0.1</ome-xml.version>
 
 		<!-- Bio-Formats - https://github.com/openmicroscopy/bioformats -->
-		<bio-formats.version>6.1.0</bio-formats.version>
+		<bio-formats.version>6.1.1</bio-formats.version>
 		<bio-formats_plugins.version>${bio-formats.version}</bio-formats_plugins.version>
 		<formats-api.version>${bio-formats.version}</formats-api.version>
 		<formats-bsd.version>${bio-formats.version}</formats-bsd.version>


### PR DESCRIPTION
Bumping the Bio-Formats version to the latest - 6.1.1
See release notes at https://www.openmicroscopy.org/2019/06/12/bio-formats-6-1-1.html