### PR TITLE
Bump Bio-Formats version to 6.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -586,7 +586,7 @@
 		<ome-xml.version>6.0.1</ome-xml.version>
 
 		<!-- Bio-Formats - https://github.com/openmicroscopy/bioformats -->
-		<bio-formats.version>6.1.1</bio-formats.version>
+		<bio-formats.version>6.2.0</bio-formats.version>
 		<bio-formats_plugins.version>${bio-formats.version}</bio-formats_plugins.version>
 		<formats-api.version>${bio-formats.version}</formats-api.version>
 		<formats-bsd.version>${bio-formats.version}</formats-bsd.version>


### PR DESCRIPTION
Bumping Bio-Formats version to 6.2.0 
See release notes at https://www.openmicroscopy.org/2019/07/18/bio-formats-6-2-0.html