### PR TITLE
Updater V1 changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -637,6 +637,10 @@
 		<!-- Apache Spark - https://spark.apache.org/ -->
 		<spark.version>2.3.1</spark.version>
 
+		<!-- Apache HTTPComponents - https://hc.apache.org/ -->
+		<apache-httpclient.version>4.5.6</apache-httpclient.version>
+		<apache-httpcore.version>4.4.11</apache-httpcore.version>
+
 		<!-- Batik - https://xmlgraphics.apache.org/batik/ -->
 		<batik.version>1.11</batik.version>
 		<batik-anim.version>${batik.version}</batik-anim.version>
@@ -707,6 +711,9 @@
 
 		<!-- iText PDF - https://github.com/itext/itextpdf -->
 		<itextpdf.version>5.5.13.1</itextpdf.version>
+
+		<!-- Apache Jackrabbit WEBDAV Library - https://jackrabbit.apache.org/jcr/components/jackrabbit-webdav-library.html -->
+		<jackrabbit-webdav.version>2.19.3</jackrabbit-webdav.version>
 
 		<!-- Java Advanced Imaging - https://java.net/projects/jai-core -->
 		<jai.version>1.1.3</jai.version>
@@ -2457,6 +2464,23 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
+			<!-- Apache HTTPComponents - https://hc.apache.org/ -->
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpclient</artifactId>
+				<version>${apache-httpclient.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>commons-logging</groupId>
+						<artifactId>commons-logging</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpcore</artifactId>
+				<version>${apache-httpcore.version}</version>
+			</dependency>
 			<!-- Batik - https://xmlgraphics.apache.org/batik/ -->
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
@@ -2803,6 +2827,13 @@
 				<groupId>com.itextpdf</groupId>
 				<artifactId>itextpdf</artifactId>
 				<version>${itextpdf.version}</version>
+			</dependency>
+
+			<!-- Apache Jackrabbit WEBDAV Library - https://jackrabbit.apache.org/jcr/components/jackrabbit-webdav-library.html -->
+			<dependency>
+				<groupId>org.apache.jackrabbit</groupId>
+				<artifactId>jackrabbit-webdav</artifactId>
+				<version>${jackrabbit-webdav.version}</version>
 			</dependency>
 
 			<!-- Java Advanced Imaging - https://java.net/projects/jai-core -->

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
 		<imagej-plugins-uploader-ssh.version>0.3.2</imagej-plugins-uploader-ssh.version>
 
 		<!-- ImageJ Plugins: Uploader: WebDAV - https://github.com/imagej/imagej-plugins-uploader-webdav -->
-		<imagej-plugins-uploader-webdav.version>0.2.2</imagej-plugins-uploader-webdav.version>
+		<imagej-plugins-uploader-webdav.version>0.3.1</imagej-plugins-uploader-webdav.version>
 
 		<!-- ImageJ Scripting - https://github.com/imagej/imagej-scripting -->
 		<imagej-scripting.version>0.8.2</imagej-scripting.version>
@@ -324,10 +324,10 @@
 		<imagej-ui-awt.version>0.3.1</imagej-ui-awt.version>
 
 		<!-- ImageJ UI: Swing - https://github.com/imagej/imagej-ui-swing -->
-		<imagej-ui-swing.version>0.22.0</imagej-ui-swing.version>
+		<imagej-ui-swing.version>0.23.1</imagej-ui-swing.version>
 
 		<!-- ImageJ Updater - https://github.com/imagej/imagej-updater -->
-		<imagej-updater.version>0.9.3</imagej-updater.version>
+		<imagej-updater.version>0.10.1</imagej-updater.version>
 
 		<!-- ImageJ Usage - https://github.com/imagej/imagej-usage -->
 		<imagej-usage.version>0.4.1</imagej-usage.version>

--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
 		<imagej-ui-swing.version>0.23.1</imagej-ui-swing.version>
 
 		<!-- ImageJ Updater - https://github.com/imagej/imagej-updater -->
-		<imagej-updater.version>0.10.1</imagej-updater.version>
+		<imagej-updater.version>0.10.3</imagej-updater.version>
 
 		<!-- ImageJ Usage - https://github.com/imagej/imagej-usage -->
 		<imagej-usage.version>0.4.1</imagej-usage.version>


### PR DESCRIPTION
* imagej-scijava-plugins-uploader-webdav: 0.2.2 -> 0.3.1
* imagej-ui-swing: 0.22.0 -> 0.23.1
* imagej-updater: 0.9.3 -> 0.10.1

This is the first stage of a new updater - a version which checks the Java support of our HTTPS certificate and changes the URLs of update sites depending on that. It can also handle changes to URLs on the list of available update sites (in the original version these changes were ignored). Changes to an activated update site URL always have to be approved by the user before they are applied.

More info: https://imagej.net/UpdaterV1