### PR TITLE
update miglayout version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -826,6 +826,8 @@
 
 		<!-- MigLayout - http://www.miglayout.com/ -->
 		<miglayout.version>5.2</miglayout.version>
+		<miglayout-core.version>${miglayout.version}</miglayout-core.version>
+		<miglayout-swing.version>${miglayout.version}</miglayout-swing.version>
 
 		<!-- Mines JTK - https://github.com/dhale/jtk -->
 		<mines-jtk.version>20151125</mines-jtk.version>
@@ -3175,13 +3177,12 @@
 			<dependency>
 				<groupId>com.miglayout</groupId>
 				<artifactId>miglayout-core</artifactId>
-				<version>${miglayout.version}</version>
+				<version>${miglayout-core.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.miglayout</groupId>
 				<artifactId>miglayout-swing</artifactId>
-				<version>${miglayout.version}</version>
-				<classifier>swing</classifier>
+				<version>${miglayout-swing.version}</version>
 			</dependency>
 
 			<!-- Mines JTK - https://github.com/dhale/jtk -->

--- a/pom.xml
+++ b/pom.xml
@@ -825,7 +825,7 @@
 		<mapdb.version>3.0.7</mapdb.version>
 
 		<!-- MigLayout - http://www.miglayout.com/ -->
-		<miglayout.version>3.7.4</miglayout.version>
+		<miglayout.version>5.2</miglayout.version>
 
 		<!-- Mines JTK - https://github.com/dhale/jtk -->
 		<mines-jtk.version>20151125</mines-jtk.version>
@@ -3174,7 +3174,12 @@
 			<!-- MigLayout - http://www.miglayout.com/ -->
 			<dependency>
 				<groupId>com.miglayout</groupId>
-				<artifactId>miglayout</artifactId>
+				<artifactId>miglayout-core</artifactId>
+				<version>${miglayout.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.miglayout</groupId>
+				<artifactId>miglayout-swing</artifactId>
 				<version>${miglayout.version}</version>
 				<classifier>swing</classifier>
 			</dependency>


### PR DESCRIPTION
Would it be possible to update to the more recent miglayout 5.2. This will require adding miglayout-core as an additional jar because now it is a dependency of miglayout-swing.

We are developing a javafx gui that uses the miglayout-javafx and this change will allow compatibility. Maybe miglayout-javafx should also be added, but I am not sure if other projects use it.

I have tested this update on my local Fiji and haven't see any issues. We are happy to perform any specific tests that might reveal issues.