### PR TITLE
Bump Bio-Formats version to 6.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -575,7 +575,7 @@
 		<!-- Open Microscopy Environment - https://github.com/ome -->
 
 		<!-- OME Common Java - https://github.com/ome/ome-common-java -->
-		<ome-common.version>6.0.3</ome-common.version>
+		<ome-common.version>6.0.4</ome-common.version>
 
 		<!-- Metakit - https://github.com/ome/ome-metakit -->
 		<metakit.version>5.3.2</metakit.version>
@@ -587,7 +587,7 @@
 		<ome-xml.version>6.0.1</ome-xml.version>
 
 		<!-- Bio-Formats - https://github.com/ome/bioformats -->
-		<bio-formats.version>6.2.1</bio-formats.version>
+		<bio-formats.version>6.3.0</bio-formats.version>
 		<bio-formats_plugins.version>${bio-formats.version}</bio-formats_plugins.version>
 		<formats-api.version>${bio-formats.version}</formats-api.version>
 		<formats-bsd.version>${bio-formats.version}</formats-bsd.version>


### PR DESCRIPTION
See https://forum.image.sc/t/release-of-bio-formats-6-3-0/30777

This release increments the minor version, most of the changes revolve around reader implementations and a couple of backwards compatible API were introduced. As such, it should not have any breaking impact on consumers of pom-scijava.