### PR TITLE
Update N5 configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -661,11 +661,11 @@
 		<!-- N5 - https://github.com/saalfeldlab/n5 -->
 
 		<imglib2-label-multisets.version>0.9.0</imglib2-label-multisets.version>
-		<n5.version>2.1.4</n5.version>
-		<n5-imglib2.version>3.4.1</n5-imglib2.version>
+		<n5.version>2.2.0</n5.version>
+		<n5-imglib2.version>3.5.0</n5-imglib2.version>
 		<n5-hdf5.version>1.0.4</n5-hdf5.version>
-		<n5-aws-s3.version>3.0.0</n5-aws-s3.version>
-		<n5-google-cloud.version>2.3.1</n5-google-cloud.version>
+		<n5-aws-s3.version>3.1.1</n5-aws-s3.version>
+		<n5-google-cloud.version>3.2.1</n5-google-cloud.version>
 		<n5-viewer_fiji.version>2.2.0</n5-viewer_fiji.version>
 
 		<!--

--- a/pom.xml
+++ b/pom.xml
@@ -872,7 +872,7 @@
 		<jackrabbit-webdav.version>2.21.0</jackrabbit-webdav.version>
 
 		<!-- Jackson - https://github.com/FasterXML/jackson -->
-		<jackson-databind.version>2.10.2</jackson-databind.version>
+		<jackson-databind.version>2.6.7.3</jackson-databind.version>
 
 		<!-- Java Advanced Imaging - https://java.net/projects/jai-core -->
 		<jai.version>1.1.3</jai.version>

--- a/pom.xml
+++ b/pom.xml
@@ -853,11 +853,8 @@
 		<cglib.version>3.3.0</cglib.version>
 
 		<!-- Google Cloud Storage - https://github.com/googleapis/google-cloud-java -->
-		<google-api-services-oauth2.version>v2-rev20190313-1.30.8</google-api-services-oauth2.version>
-		<google-cloud-resourcemanager.version>0.117.1-alpha</google-cloud-resourcemanager.version>
-		<google-cloud-storage.version>1.104.0</google-cloud-storage.version>
-		<google-http-client-jackson2.version>1.34.2</google-http-client-jackson2.version>
-		<google-oauth-client-jetty.version>1.30.5</google-oauth-client-jetty.version>
+		<google-cloud-resourcemanager.version>0.117.2-alpha</google-cloud-resourcemanager.version>
+		<google-cloud-storage.version>1.106.0</google-cloud-storage.version>
 
 		<!-- Gson - https://code.google.com/p/google-gson/ -->
 		<gson.version>2.8.6</gson.version>
@@ -3130,11 +3127,6 @@
 
 			<!-- Google Cloud Storage - https://github.com/googleapis/google-cloud-java -->
 			<dependency>
-				<groupId>com.google.apis</groupId>
-				<artifactId>google-api-services-oauth2</artifactId>
-				<version>${google-api-services-oauth2.version}</version>
-			</dependency>
-			<dependency>
 				<groupId>com.google.cloud</groupId>
 				<artifactId>google-cloud-resourcemanager</artifactId>
 				<version>${google-cloud-resourcemanager.version}</version>
@@ -3143,16 +3135,6 @@
 				<groupId>com.google.cloud</groupId>
 				<artifactId>google-cloud-storage</artifactId>
 				<version>${google-cloud-storage.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.google.http-client</groupId>
-				<artifactId>google-http-client-jackson2</artifactId>
-				<version>${google-http-client-jackson2.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.google.oauth-client</groupId>
-				<artifactId>google-oauth-client-jetty</artifactId>
-				<version>${google-oauth-client-jetty.version}</version>
 			</dependency>
 
 			<!-- Gson - https://code.google.com/p/google-gson/ -->


### PR DESCRIPTION
* Bump versions of N5-related artifacts
* Remove some of the Google Cloud SDK dependencies that are not needed anymore in newer `n5-google-cloud`
* Downgrade `jackson-databind` because Spark and AWS SDK still use an older version and were producing runtime errors if running with the newer version