### PR TITLE
Add Eclipse Collections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -942,6 +942,9 @@
 		
 		<!--  Eclipse Collections - https://www.eclipse.org/collections/ -->
 		<eclipse-collections.version>10.2.0</eclipse-collections.version>
+		<eclipse-collections-api.version>${eclipse-collections.version}</eclipse-collections-api.version>
+		<eclipse-collections-forkjoin.version>${eclipse-collections.version}</eclipse-collections-forkjoin.version>
+		<eclipse-collections-testutils.version>${eclipse-collections.version}</eclipse-collections-testutils.version>
 
 		<!-- Eclipse SWT - https://www.eclipse.org/swt/ -->
 		<eclipse-swt.version>4.3</eclipse-swt.version>
@@ -3359,15 +3362,24 @@
 
 			<!-- Eclipse Collections - https://www.eclipse.org/collections/ -->
 			<dependency>
-  				<groupId>org.eclipse.collections</groupId>
-  				<artifactId>eclipse-collections-api</artifactId>
-  				<version>${eclipse-collections.version}</version>
+				<groupId>org.eclipse.collections</groupId>
+				<artifactId>eclipse-collections</artifactId>
+				<version>${eclipse-collections.version}</version>
 			</dependency>
-
 			<dependency>
-  				<groupId>org.eclipse.collections</groupId>
-  				<artifactId>eclipse-collections</artifactId>
-  				<version>${eclipse-collections.version}</version>
+				<groupId>org.eclipse.collections</groupId>
+				<artifactId>eclipse-collections-api</artifactId>
+				<version>${eclipse-collections-api.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.collections</groupId>
+				<artifactId>eclipse-collections-forkjoin</artifactId>
+				<version>${eclipse-collections-forkjoin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.collections</groupId>
+				<artifactId>eclipse-collections-testutils</artifactId>
+				<version>${eclipse-collections-testutils.version}</version>
 			</dependency>
 
 			<!-- Eclipse SWT - https://www.eclipse.org/swt/ -->

--- a/pom.xml
+++ b/pom.xml
@@ -939,6 +939,9 @@
 
 		<!-- Byte Code Generation Library - https://github.com/cglib/cglib -->
 		<cglib.version>3.3.0</cglib.version>
+		
+		<!--  Eclipse Collections - https://www.eclipse.org/collections/ -->
+		<eclipse-collections.version>10.2.0</eclipse-collections.version>
 
 		<!-- Eclipse SWT - https://www.eclipse.org/swt/ -->
 		<eclipse-swt.version>4.3</eclipse-swt.version>
@@ -3352,6 +3355,19 @@
 				<groupId>cglib</groupId>
 				<artifactId>cglib</artifactId>
 				<version>${cglib.version}</version>
+			</dependency>
+
+			<!-- Eclipse Collections - https://www.eclipse.org/collections/ -->
+			<dependency>
+  				<groupId>org.eclipse.collections</groupId>
+  				<artifactId>eclipse-collections-api</artifactId>
+  				<version>${eclipse-collections.version}</version>
+			</dependency>
+
+			<dependency>
+  				<groupId>org.eclipse.collections</groupId>
+  				<artifactId>eclipse-collections</artifactId>
+  				<version>${eclipse-collections.version}</version>
 			</dependency>
 
 			<!-- Eclipse SWT - https://www.eclipse.org/swt/ -->


### PR DESCRIPTION
[Eclipse Collections](https://www.eclipse.org/collections/) is a Java collections framework containing useful and high performance replacements for JDK's default collections. For example, HashSet<Integer> can be replaced by the primitive collection IntHashSet. It is in general faster than Trove by a factor of 1.5-3×, and is actively maintained at [https://github.com/eclipse/eclipse-collections](https://github.com/eclipse/eclipse-collections).