### PR TITLE
Bump Bio-Formats version to 6.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -770,7 +770,7 @@
 		<jxrlib-all.version>${jxrlib.version}</jxrlib-all.version>
 
 		<!-- Bio-Formats - https://github.com/ome/bioformats -->
-		<bio-formats.version>6.6.0</bio-formats.version>
+		<bio-formats.version>6.6.1</bio-formats.version>
 		<bio-formats_plugins.version>${bio-formats.version}</bio-formats_plugins.version>
 		<formats-api.version>${bio-formats.version}</formats-api.version>
 		<formats-bsd.version>${bio-formats.version}</formats-bsd.version>

--- a/pom.xml
+++ b/pom.xml
@@ -770,7 +770,7 @@
 		<jxrlib-all.version>${jxrlib.version}</jxrlib-all.version>
 
 		<!-- Bio-Formats - https://github.com/ome/bioformats -->
-		<bio-formats.version>6.5.1</bio-formats.version>
+		<bio-formats.version>6.6.0</bio-formats.version>
 		<bio-formats_plugins.version>${bio-formats.version}</bio-formats_plugins.version>
 		<formats-api.version>${bio-formats.version}</formats-api.version>
 		<formats-bsd.version>${bio-formats.version}</formats-bsd.version>


### PR DESCRIPTION
Bumping to the latest minor release of Bio-Formats.
https://forum.image.sc/t/release-of-bio-formats-6-6-0/46644 for details of what is included

Note that this includes the kyro dependency bumps from https://github.com/ome/ome-common-java/pull/50 and https://github.com/ome/bioformats/pull/3557

We have also added a new reader which requires an additional dependency of `sqlite-jdbc` version 3.28.0 (https://github.com/ome/bioformats/pull/3637/files#diff-163d06c24353c2092cb730eb800f3df44cf4db6ea72c5fcdf63b1c3e8f741274). Would it be possible to get this additional dependency included also?