### PR TITLE
Bump Bio-Formats version to 6.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -770,7 +770,7 @@
 		<jxrlib-all.version>${jxrlib.version}</jxrlib-all.version>
 
 		<!-- Bio-Formats - https://github.com/ome/bioformats -->
-		<bio-formats.version>6.7.0</bio-formats.version>
+		<bio-formats.version>6.8.0</bio-formats.version>
 		<bio-formats_plugins.version>${bio-formats.version}</bio-formats_plugins.version>
 		<formats-api.version>${bio-formats.version}</formats-api.version>
 		<formats-bsd.version>${bio-formats.version}</formats-bsd.version>

--- a/pom.xml
+++ b/pom.xml
@@ -770,7 +770,7 @@
 		<jxrlib-all.version>${jxrlib.version}</jxrlib-all.version>
 
 		<!-- Bio-Formats - https://github.com/ome/bioformats -->
-		<bio-formats.version>6.8.0</bio-formats.version>
+		<bio-formats.version>6.8.1</bio-formats.version>
 		<bio-formats_plugins.version>${bio-formats.version}</bio-formats_plugins.version>
 		<formats-api.version>${bio-formats.version}</formats-api.version>
 		<formats-bsd.version>${bio-formats.version}</formats-bsd.version>


### PR DESCRIPTION
Bumping to the latest minor release of Bio-Formats.
https://forum.image.sc/t/release-of-bio-formats-6-8-0/60895 for details on what all is included

One particular note on some of the dependencies bumps:
- we have bumped jhdf5 to version 19.04.0
- we have bumped commons-lang to version 2.6
- we have added a new dependency to support zstd compression for CZI files
```
      <groupId>io.airlift</groupId>
      <artifactId>aircompressor</artifactId>
      <version>0.18</version>
```