### PR TITLE
Bump Bio-Formats version to 6.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1140,7 +1140,7 @@
 		<ome.jxrlib-all.version>${jxrlib-all.version}</ome.jxrlib-all.version>
 
 		<!-- Bio-Formats - https://github.com/ome/bioformats -->
-		<bio-formats.version>6.9.0</bio-formats.version>
+		<bio-formats.version>6.9.1</bio-formats.version>
 		<bio-formats_plugins.version>${bio-formats.version}</bio-formats_plugins.version>
 		<formats-api.version>${bio-formats.version}</formats-api.version>
 		<formats-bsd.version>${bio-formats.version}</formats-bsd.version>


### PR DESCRIPTION
Bumping to the latest patch release of Bio-Formats. See https://forum.image.sc/t/release-of-bio-formats-6-9-1/65985 for full details of the changes included.