### PR TITLE
Bump Bio-Formats version to 6.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1136,7 +1136,7 @@
 		<ome.jxrlib-all.version>${jxrlib-all.version}</ome.jxrlib-all.version>
 
 		<!-- Bio-Formats - https://github.com/ome/bioformats -->
-		<bio-formats.version>6.9.1</bio-formats.version>
+		<bio-formats.version>6.10.0</bio-formats.version>
 		<bio-formats-tools.version>${bio-formats.version}</bio-formats-tools.version>
 		<bio-formats_plugins.version>${bio-formats.version}</bio-formats_plugins.version>
 		<formats-api.version>${bio-formats.version}</formats-api.version>


### PR DESCRIPTION
Bumping to the latest minor release of Bio-Formats. See https://forum.image.sc/t/release-of-bio-formats-6-10-0/67720 for full details of the changes included.

This includes a number of component updates, most notably:
```
logback-core was upgraded to 1.2.9
logback-classic was upgraded to 1.2.9
xercesImpl was upgraded to 2.12.2
xml-apis was upgraded to 1.4.01
snakeyaml 1.29 was added as a dependency
```