### PR TITLE
upgrade jna version to 5.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1682,7 +1682,7 @@
 		<org.jmockit.jmockit.version>${jmockit.version}</org.jmockit.jmockit.version>
 
 		<!-- JNA - https://github.com/twall/jna -->
-		<jna.version>4.5.2</jna.version>
+		<jna.version>5.11.0</jna.version>
 		<net.java.dev.jna.jna.version>${jna.version}</net.java.dev.jna.jna.version>
 
 		<!-- Joda-Time - https://www.joda.org/joda-time/ -->


### PR DESCRIPTION
Regarding the issue: https://github.com/scijava/pom-scijava/issues/201
A newer JNA version is needed to be able to load c-blosc from homebrew in the new MacBook.
