### PR TITLE
Update rsyntaxtextarea components to v3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1969,9 +1969,9 @@
 		<ch.qos.reload4j.reload4j.version>${reload4j.version}</ch.qos.reload4j.reload4j.version>
 
 		<!-- RSyntaxTextArea - https://bobbylight.github.io/RSyntaxTextArea/ -->
-		<rsyntaxtextarea.version>3.1.6</rsyntaxtextarea.version>
-		<autocomplete.version>3.1.5</autocomplete.version>
-		<languagesupport.version>3.1.4</languagesupport.version>
+		<rsyntaxtextarea.version>3.3.0</rsyntaxtextarea.version>
+		<autocomplete.version>3.3.0</autocomplete.version>
+		<languagesupport.version>3.3.0</languagesupport.version>
 		<com.fifesoft.rsyntaxtextarea.version>${rsyntaxtextarea.version}</com.fifesoft.rsyntaxtextarea.version>
 		<com.fifesoft.autocomplete.version>${autocomplete.version}</com.fifesoft.autocomplete.version>
 		<com.fifesoft.languagesupport.version>${languagesupport.version}</com.fifesoft.languagesupport.version>

--- a/pom.xml
+++ b/pom.xml
@@ -403,7 +403,7 @@
 		<org.scijava.scijava-ui-swing.version>${scijava-ui-swing.version}</org.scijava.scijava-ui-swing.version>
 
 		<!-- Script Editor - https://github.com/scijava/script-editor -->
-		<script-editor.version>0.7.8</script-editor.version>
+		<script-editor.version>0.7.9</script-editor.version>
 		<org.scijava.script-editor.version>${script-editor.version}</org.scijava.script-editor.version>
 
 		<!-- Script Editor: Jython - https://github.com/scijava/script-editor-jython -->


### PR DESCRIPTION
This bring improvements across the board to the script editor
(NB: there has been a tiny change in the rsyntaxtextarea API, and https://github.com/scijava/script-editor/pull/64 will be required to compile the script editor under these versions).