### PR TITLE
Update FlatLaf to v3.1.1 + Jetbrains Mono

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1626,8 +1626,10 @@
 		<com.google.errorprone.error_prone_annotations.version>${error_prone_annotations.version}</com.google.errorprone.error_prone_annotations.version>
 
 		<!-- FlatLaf - https://www.formdev.com/flatlaf/ -->
-		<flatlaf.version>2.6</flatlaf.version>
+		<flatlaf.version>3.1.1</flatlaf.version>
 		<com.formdev.flatlaf.version>${flatlaf.version}</com.formdev.flatlaf.version>
+		<flatlaf-fonts-jetbrains-mono.version>2.242</flatlaf-fonts-jetbrains-mono.version>
+		<com.formdev.flatlaf-fonts-jetbrains-mono.version>${flatlaf-fonts-jetbrains-mono.version}</com.formdev.flatlaf-fonts-jetbrains-mono.version>
 
 		<!-- Google APIs Client - https://github.com/googleapis/google-api-java-client -->
 		<google-api-client.version>2.2.0</google-api-client.version>


### PR DESCRIPTION
This brings bug fixes, MacOS 'native' themes, and [JetBrains Mono](https://www.jetbrains.com/lp/mono/), the coding font used by JetBrains software.