### PR TITLE
Bump Bio-Formats version to 6.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1230,7 +1230,7 @@
 		<ome.jxrlib-all.version>${jxrlib-all.version}</ome.jxrlib-all.version>
 
 		<!-- Bio-Formats - https://github.com/ome/bioformats -->
-		<bio-formats.version>6.12.0</bio-formats.version>
+		<bio-formats.version>6.13.0</bio-formats.version>
 		<bio-formats-tools.version>${bio-formats.version}</bio-formats-tools.version>
 		<bio-formats_plugins.version>${bio-formats.version}</bio-formats_plugins.version>
 		<formats-api.version>${bio-formats.version}</formats-api.version>


### PR DESCRIPTION
Bumping to the latest patch release of Bio-Formats. See https://forum.image.sc/t/release-of-bio-formats-6-13-0/80689 for full details of the changes included. This includes the dependency bumps from https://github.com/ome/bioformats/issues/3970 to bring Bio-Formats up to date with the changes discussed in https://forum.image.sc/t/plugin-maintainers-can-you-test-fiji-2-11-0/78852/14