### PR TITLE
Bump n5 artifact versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1178,7 +1178,7 @@
 		<net.haesleinhuepf.clijx-weka_.version>${clijx-weka_.version}</net.haesleinhuepf.clijx-weka_.version>
 
 		<!-- BigStitcher - https://imagej.net/plugins/bigstitcher -->
-		<BigStitcher.version>1.1.6</BigStitcher.version>
+		<BigStitcher.version>1.2.6</BigStitcher.version>
 		<multiview-reconstruction.version>3.2.3</multiview-reconstruction.version>
 		<multiview-simulation.version>0.2.0</multiview-simulation.version>
 		<net.preibisch.BigStitcher.version>${BigStitcher.version}</net.preibisch.BigStitcher.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>pom-scijava</artifactId>
-	<version>36.0.1-SNAPSHOT</version>
+	<version>37.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>SciJava Parent POM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1109,7 +1109,7 @@
 		<net.imglib2.imglib2-label-multisets.version>${imglib2-label-multisets.version}</net.imglib2.imglib2-label-multisets.version>
 
 		<!-- N5 - https://github.com/saalfeldlab/n5 -->
-		<n5.version>3.0.1</n5.version>
+		<n5.version>3.0.2</n5.version>
 		<org.janelia.saalfeldlab.n5.version>${n5.version}</org.janelia.saalfeldlab.n5.version>
 
 		<!-- N5 AWS S3 - https://github.com/saalfeldlab/n5-aws-s3 -->
@@ -1145,7 +1145,7 @@
 		<org.janelia.saalfeldlab.n5-viewer_fiji.version>${n5-viewer_fiji.version}</org.janelia.saalfeldlab.n5-viewer_fiji.version>
 
 		<!-- N5 Zarr - https://github.com/saalfeldlab/n5-zarr -->
-		<n5-zarr.version>1.0.0</n5-zarr.version>
+		<n5-zarr.version>1.0.1</n5-zarr.version>
 		<org.janelia.saalfeldlab.n5-zarr.version>${n5-zarr.version}</org.janelia.saalfeldlab.n5-zarr.version>
 
 		<!-- N5 Universe - https://github.com/saalfeldlab/n5-universe -->

--- a/pom.xml
+++ b/pom.xml
@@ -991,7 +991,7 @@
 		<jitk.jitk-tps.version>${jitk-tps.version}</jitk.jitk-tps.version>
 
 		<!-- BigWarp - https://github.com/saalfeldlab/bigwarp -->
-		<bigwarp.version>7.0.7</bigwarp.version>
+		<bigwarp.version>8.0.0</bigwarp.version>
 		<bigwarp_fiji.version>${bigwarp.version}</bigwarp_fiji.version>
 		<sc.fiji.bigwarp_fiji.version>${bigwarp_fiji.version}</sc.fiji.bigwarp_fiji.version>
 
@@ -1012,7 +1012,7 @@
 		<!-- BigDataViewer - https://github.com/bigdataviewer -->
 
 		<!-- BigDataViewer Core - https://github.com/bigdataviewer/bigdataviewer-core -->
-		<bigdataviewer-core.version>10.4.6</bigdataviewer-core.version>
+		<bigdataviewer-core.version>10.4.8</bigdataviewer-core.version>
 		<sc.fiji.bigdataviewer-core.version>${bigdataviewer-core.version}</sc.fiji.bigdataviewer-core.version>
 
 		<!-- BigDataServer - https://github.com/bigdataviewer/bigdataviewer-server -->
@@ -1109,11 +1109,11 @@
 		<net.imglib2.imglib2-label-multisets.version>${imglib2-label-multisets.version}</net.imglib2.imglib2-label-multisets.version>
 
 		<!-- N5 - https://github.com/saalfeldlab/n5 -->
-		<n5.version>2.5.1</n5.version>
+		<n5.version>3.0.0</n5.version>
 		<org.janelia.saalfeldlab.n5.version>${n5.version}</org.janelia.saalfeldlab.n5.version>
 
 		<!-- N5 AWS S3 - https://github.com/saalfeldlab/n5-aws-s3 -->
-		<n5-aws-s3.version>3.2.0</n5-aws-s3.version>
+		<n5-aws-s3.version>4.0.1</n5-aws-s3.version>
 		<org.janelia.saalfeldlab.n5-aws-s3.version>${n5-aws-s3.version}</org.janelia.saalfeldlab.n5-aws-s3.version>
 
 		<!-- N5 Blosc - https://github.com/saalfeldlab/n5-blosc -->
@@ -1121,28 +1121,32 @@
 		<org.janelia.saalfeldlab.n5-blosc.version>${n5-blosc.version}</org.janelia.saalfeldlab.n5-blosc.version>
 
 		<!-- N5 Google Cloud - https://github.com/saalfeldlab/n5-google-cloud -->
-		<n5-google-cloud.version>3.3.2</n5-google-cloud.version>
+		<n5-google-cloud.version>4.0.0</n5-google-cloud.version>
 		<org.janelia.saalfeldlab.n5-google-cloud.version>${n5-google-cloud.version}</org.janelia.saalfeldlab.n5-google-cloud.version>
 
 		<!-- N5 HDF5 Bindings - https://github.com/saalfeldlab/n5-hdf5 -->
-		<n5-hdf5.version>1.4.2</n5-hdf5.version>
+		<n5-hdf5.version>2.0.0</n5-hdf5.version>
 		<org.janelia.saalfeldlab.n5-hdf5.version>${n5-hdf5.version}</org.janelia.saalfeldlab.n5-hdf5.version>
 
 		<!-- N5 ImageJ Bindings - https://github.com/saalfeldlab/n5-ij -->
-		<n5-ij.version>3.2.3</n5-ij.version>
+		<n5-ij.version>3.2.6</n5-ij.version>
 		<org.janelia.saalfeldlab.n5-ij.version>${n5-ij.version}</org.janelia.saalfeldlab.n5-ij.version>
 
 		<!-- N5 ImgLib2 Bindings - https://github.com/saalfeldlab/n5-imglib2 -->
-		<n5-imglib2.version>5.0.0</n5-imglib2.version>
+		<n5-imglib2.version>7.0.0</n5-imglib2.version>
 		<org.janelia.saalfeldlab.n5-imglib2.version>${n5-imglib2.version}</org.janelia.saalfeldlab.n5-imglib2.version>
 
 		<!-- N5 Viewer for Fiji - https://github.com/saalfeldlab/n5-viewer_fiji -->
-		<n5-viewer_fiji.version>5.3.0</n5-viewer_fiji.version>
+		<n5-viewer_fiji.version>5.3.1</n5-viewer_fiji.version>
 		<org.janelia.saalfeldlab.n5-viewer_fiji.version>${n5-viewer_fiji.version}</org.janelia.saalfeldlab.n5-viewer_fiji.version>
 
 		<!-- N5 Zarr - https://github.com/saalfeldlab/n5-zarr -->
-		<n5-zarr.version>0.0.8</n5-zarr.version>
+		<n5-zarr.version>1.0.0</n5-zarr.version>
 		<org.janelia.saalfeldlab.n5-zarr.version>${n5-zarr.version}</org.janelia.saalfeldlab.n5-zarr.version>
+
+		<!-- N5 Universe - https://github.com/saalfeldlab/n5-universe -->
+		<n5-universe.version>1.1.0</n5-universe.version>
+		<org.janelia.saalfeldlab.n5-universe.version>${n5-universe.version}</org.janelia.saalfeldlab.n5-universe.version>
 
 		<!-- Fiji-adjacent projects (available from ImageJ update sites) -->
 
@@ -3628,6 +3632,11 @@
 				<groupId>org.janelia.saalfeldlab</groupId>
 				<artifactId>n5-zarr</artifactId>
 				<version>${org.janelia.saalfeldlab.n5-zarr.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.janelia.saalfeldlab</groupId>
+				<artifactId>n5-universe</artifactId>
+				<version>${org.janelia.saalfeldlab.n5-universe.version}</version>
 			</dependency>
 
 			<!-- Fiji-adjacent projects (available from ImageJ update sites) -->

--- a/pom.xml
+++ b/pom.xml
@@ -1125,7 +1125,7 @@
 		<org.janelia.saalfeldlab.n5-google-cloud.version>${n5-google-cloud.version}</org.janelia.saalfeldlab.n5-google-cloud.version>
 
 		<!-- N5 HDF5 Bindings - https://github.com/saalfeldlab/n5-hdf5 -->
-		<n5-hdf5.version>2.0.0</n5-hdf5.version>
+		<n5-hdf5.version>2.0.1</n5-hdf5.version>
 		<org.janelia.saalfeldlab.n5-hdf5.version>${n5-hdf5.version}</org.janelia.saalfeldlab.n5-hdf5.version>
 
 		<!-- N5 ImageJ Bindings - https://github.com/saalfeldlab/n5-ij -->

--- a/pom.xml
+++ b/pom.xml
@@ -1148,10 +1148,6 @@
 		<n5-zarr.version>1.0.1</n5-zarr.version>
 		<org.janelia.saalfeldlab.n5-zarr.version>${n5-zarr.version}</org.janelia.saalfeldlab.n5-zarr.version>
 
-		<!-- N5 Universe - https://github.com/saalfeldlab/n5-universe -->
-		<n5-universe.version>1.1.0</n5-universe.version>
-		<org.janelia.saalfeldlab.n5-universe.version>${n5-universe.version}</org.janelia.saalfeldlab.n5-universe.version>
-
 		<!-- Fiji-adjacent projects (available from ImageJ update sites) -->
 
 		<!-- MorphoLibJ - https://imagej.net/plugins/morpholibj -->

--- a/pom.xml
+++ b/pom.xml
@@ -1109,7 +1109,7 @@
 		<net.imglib2.imglib2-label-multisets.version>${imglib2-label-multisets.version}</net.imglib2.imglib2-label-multisets.version>
 
 		<!-- N5 - https://github.com/saalfeldlab/n5 -->
-		<n5.version>3.0.0</n5.version>
+		<n5.version>3.0.1</n5.version>
 		<org.janelia.saalfeldlab.n5.version>${n5.version}</org.janelia.saalfeldlab.n5.version>
 
 		<!-- N5 AWS S3 - https://github.com/saalfeldlab/n5-aws-s3 -->
@@ -1117,7 +1117,7 @@
 		<org.janelia.saalfeldlab.n5-aws-s3.version>${n5-aws-s3.version}</org.janelia.saalfeldlab.n5-aws-s3.version>
 
 		<!-- N5 Blosc - https://github.com/saalfeldlab/n5-blosc -->
-		<n5-blosc.version>1.1.0</n5-blosc.version>
+		<n5-blosc.version>1.1.1</n5-blosc.version>
 		<org.janelia.saalfeldlab.n5-blosc.version>${n5-blosc.version}</org.janelia.saalfeldlab.n5-blosc.version>
 
 		<!-- N5 Google Cloud - https://github.com/saalfeldlab/n5-google-cloud -->
@@ -1175,7 +1175,7 @@
 
 		<!-- BigStitcher - https://imagej.net/plugins/bigstitcher -->
 		<BigStitcher.version>1.1.6</BigStitcher.version>
-		<multiview-reconstruction.version>2.0.0</multiview-reconstruction.version>
+		<multiview-reconstruction.version>3.2.3</multiview-reconstruction.version>
 		<multiview-simulation.version>0.2.0</multiview-simulation.version>
 		<net.preibisch.BigStitcher.version>${BigStitcher.version}</net.preibisch.BigStitcher.version>
 		<net.preibisch.multiview-reconstruction.version>${multiview-reconstruction.version}</net.preibisch.multiview-reconstruction.version>


### PR DESCRIPTION
This commit updates the versions of many n5 artifacts, many of them major version bumps.
It also adds a new artifact: `n5-universe`, and updates the versions of some packages depending
on n5: `bigdataviewer-core`, and `bigwarp`


@ctrueden  I'm not sure how pom-scijava semver updates go, but I bumped the major version 
in its own commit. Please revert / change if that wasn't the right thing to do.
