### PR TITLE
Bump Bio-Formats version to 7.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1238,7 +1238,7 @@
 		<ome.jxrlib-all.version>${jxrlib-all.version}</ome.jxrlib-all.version>
 
 		<!-- Bio-Formats - https://github.com/ome/bioformats -->
-		<bio-formats.version>7.0.1</bio-formats.version>
+		<bio-formats.version>7.1.0</bio-formats.version>
 		<bio-formats-tools.version>${bio-formats.version}</bio-formats-tools.version>
 		<bio-formats_plugins.version>${bio-formats.version}</bio-formats_plugins.version>
 		<formats-api.version>${bio-formats.version}</formats-api.version>


### PR DESCRIPTION
Bumping to the latest release of Bio-Formats, which includes a number of dependency updates. See [here](https://forum.image.sc/t/release-of-bio-formats-7-1-0/89725) for full details of the changes included.