### PR TITLE
bump imglib2-label-multisets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1099,7 +1099,7 @@
 		<!-- N5 - https://github.com/saalfeldlab/n5 -->
 
 		<!-- ImgLib2 Label Multisets - https://github.com/saalfeldlab/imglib2-label-multisets -->
-		<imglib2-label-multisets.version>0.11.5</imglib2-label-multisets.version>
+		<imglib2-label-multisets.version>0.13.0</imglib2-label-multisets.version>
 		<net.imglib2.imglib2-label-multisets.version>${imglib2-label-multisets.version}</net.imglib2.imglib2-label-multisets.version>
 
 		<!-- N5 - https://github.com/saalfeldlab/n5 -->


### PR DESCRIPTION
Add's more functionality to LabelMultisetType and refactor serialization/deserialization. Fix a serialization related bug from 0.12.0