### PR TITLE
Update pom.xml with Mockito 5.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2229,7 +2229,7 @@
 		<edu.mines.mines-jtk.version>${mines-jtk.version}</edu.mines.mines-jtk.version>
 
 		<!-- Mockito - https://site.mockito.org/ -->
-		<mockito.version>2.19.0</mockito.version>
+		<mockito.version>5.11.0</mockito.version>
 		<mockito-core.version>${mockito.version}</mockito-core.version>
 		<org.mockito.mockito-core.version>${mockito-core.version}</org.mockito.mockito-core.version>
 


### PR DESCRIPTION
Old Mockito 2.19.0 was resulting in tests failing to run, under Eclipse and Maven and Java 11. Updating to newer versions helps. This version (5.11.0) is the newest available today.