### PR TITLE
Update pom.xml to use Mockito 4.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2229,7 +2229,7 @@
 		<edu.mines.mines-jtk.version>${mines-jtk.version}</edu.mines.mines-jtk.version>
 
 		<!-- Mockito - https://site.mockito.org/ -->
-		<mockito.version>2.19.0</mockito.version>
+		<mockito.version>4.11.0</mockito.version>
 		<mockito-core.version>${mockito.version}</mockito-core.version>
 		<org.mockito.mockito-core.version>${mockito-core.version}</org.mockito.mockito-core.version>
 


### PR DESCRIPTION
Mockito 4.11.0 is the last version that supports Java 8. The previous version stopped working with Maven, Eclipse, etc.