### PR TITLE
bump imglib2-label-multiset for bugfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1104,7 +1104,7 @@
 		<!-- N5 - https://github.com/saalfeldlab/n5 -->
 
 		<!-- ImgLib2 Label Multisets - https://github.com/saalfeldlab/imglib2-label-multisets -->
-		<imglib2-label-multisets.version>0.13.0</imglib2-label-multisets.version>
+		<imglib2-label-multisets.version>0.13.1</imglib2-label-multisets.version>
 		<net.imglib2.imglib2-label-multisets.version>${imglib2-label-multisets.version}</net.imglib2.imglib2-label-multisets.version>
 
 		<!-- N5 - https://github.com/saalfeldlab/n5 -->


### PR DESCRIPTION
bugfix version bump of imglib2-label-multisets from `0.13.0` -> `0.13.1` 