### PR TITLE
Update scijava-ui-swing version to newest release 1.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -394,7 +394,7 @@
 		<org.scijava.scijava-ui-awt.version>${scijava-ui-awt.version}</org.scijava.scijava-ui-awt.version>
 
 		<!-- SciJava UI: Swing - https://github.com/scijava/scijava-ui-swing -->
-		<scijava-ui-swing.version>1.0.1</scijava-ui-swing.version>
+		<scijava-ui-swing.version>1.0.2</scijava-ui-swing.version>
 		<org.scijava.scijava-ui-swing.version>${scijava-ui-swing.version}</org.scijava.scijava-ui-swing.version>
 
 		<!-- Script Editor - https://github.com/scijava/script-editor -->


### PR DESCRIPTION
There is a new release of scijava-ui-swing: https://maven.scijava.org/#nexus-search;gav~org.scijava~scijava-ui-swing~1.0.2~~
Thus the version of scijava-ui-swing could be updated.