### PR TITLE
Update bigdataviewer-core to 10.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1012,7 +1012,7 @@
 		<!-- BigDataViewer - https://github.com/bigdataviewer -->
 
 		<!-- BigDataViewer Core - https://github.com/bigdataviewer/bigdataviewer-core -->
-		<bigdataviewer-core.version>10.4.14</bigdataviewer-core.version>
+		<bigdataviewer-core.version>10.5.0</bigdataviewer-core.version>
 		<sc.fiji.bigdataviewer-core.version>${bigdataviewer-core.version}</sc.fiji.bigdataviewer-core.version>
 
 		<!-- BigDataServer - https://github.com/bigdataviewer/bigdataviewer-server -->


### PR DESCRIPTION
Would it be possible to update bdv-core to 10.5.0 (and release 38.0.2) ? There's a bug fix for the UI that was released in 10.4.16. @tpietzsch @ctrueden