### PR TITLE
Update to Bio-Formats 8.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1233,15 +1233,15 @@
 		<com.zeroc.ice.version>${ice.version}</com.zeroc.ice.version>
 
 		<!-- OME Codecs - https://github.com/ome/ome-codecs -->
-		<ome-codecs.version>1.0.3</ome-codecs.version>
+		<ome-codecs.version>1.1.0</ome-codecs.version>
 		<org.openmicroscopy.ome-codecs.version>${ome-codecs.version}</org.openmicroscopy.ome-codecs.version>
 
 		<!-- OME Common Java - https://github.com/ome/ome-common-java -->
-		<ome-common.version>6.0.24</ome-common.version>
+		<ome-common.version>6.0.25</ome-common.version>
 		<org.openmicroscopy.ome-common.version>${ome-common.version}</org.openmicroscopy.ome-common.version>
 
 		<!-- Metakit - https://github.com/ome/ome-metakit -->
-		<metakit.version>5.3.7</metakit.version>
+		<metakit.version>5.3.8</metakit.version>
 		<org.openmicroscopy.metakit.version>${metakit.version}</org.openmicroscopy.metakit.version>
 
 		<!-- OME POI - https://github.com/ome/ome-poi -->
@@ -1249,7 +1249,7 @@
 		<org.openmicroscopy.ome-poi.version>${ome-poi.version}</org.openmicroscopy.ome-poi.version>
 
 		<!-- OME Model - https://github.com/ome/ome-model -->
-		<ome-model.version>6.3.6</ome-model.version>
+		<ome-model.version>6.4.0</ome-model.version>
 		<ome-xml.version>${ome-model.version}</ome-xml.version>
 		<specification.version>${ome-model.version}</specification.version>
 		<org.openmicroscopy.ome-xml.version>${ome-xml.version}</org.openmicroscopy.ome-xml.version>
@@ -1261,7 +1261,7 @@
 		<ome.jxrlib-all.version>${jxrlib-all.version}</ome.jxrlib-all.version>
 
 		<!-- Bio-Formats - https://github.com/ome/bioformats -->
-		<bio-formats.version>8.0.1</bio-formats.version>
+		<bio-formats.version>8.1.0</bio-formats.version>
 		<bio-formats-tools.version>${bio-formats.version}</bio-formats-tools.version>
 		<bio-formats_plugins.version>${bio-formats.version}</bio-formats_plugins.version>
 		<formats-api.version>${bio-formats.version}</formats-api.version>


### PR DESCRIPTION
Dependencies that were upgraded in 8.1.0 have also been updated to match here, see https://bio-formats.readthedocs.io/en/stable/about/whats-new.html#february.

Relevant changelogs for other updated dependencies:

- ome-common-java: https://github.com/ome/ome-common-java/releases/tag/v6.0.25
- ome-codecs: https://github.com/ome/ome-codecs/releases/tag/v1.1.0
- ome-metakit: https://github.com/ome/ome-metakit/releases/tag/v5.3.8
- ome-model: https://github.com/ome/ome-model/releases/tag/v6.4.0

The logback dependency intentionally hasn't been changed here, but note Bio-Formats 8.1.0 uses logback 1.3.15.