### PR TITLE
add jackson-dataformat-smile to pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1840,11 +1840,13 @@
 		<jackson-core.version>${jackson.version}</jackson-core.version>
 		<jackson-databind.version>${jackson.version}</jackson-databind.version>
 		<jackson-dataformat-cbor.version>${jackson.version}</jackson-dataformat-cbor.version>
+		<jackson-dataformat-smile.version>${jackson.version}</jackson-dataformat-smile.version>
 		<jackson-dataformat-yaml.version>${jackson.version}</jackson-dataformat-yaml.version>
 		<com.fasterxml.jackson.core.jackson-annotations.version>${jackson-annotations.version}</com.fasterxml.jackson.core.jackson-annotations.version>
 		<com.fasterxml.jackson.core.jackson-core.version>${jackson-core.version}</com.fasterxml.jackson.core.jackson-core.version>
 		<com.fasterxml.jackson.core.jackson-databind.version>${jackson-databind.version}</com.fasterxml.jackson.core.jackson-databind.version>
 		<com.fasterxml.jackson.dataformat.jackson-dataformat-cbor.version>${jackson-dataformat-cbor.version}</com.fasterxml.jackson.dataformat.jackson-dataformat-cbor.version>
+		<com.fasterxml.jackson.dataformat.jackson-dataformat-smile.version>${jackson-dataformat-smile.version}</com.fasterxml.jackson.dataformat.jackson-dataformat-smile.version>
 		<com.fasterxml.jackson.dataformat.jackson-dataformat-yaml.version>${jackson-dataformat-yaml.version}</com.fasterxml.jackson.dataformat.jackson-dataformat-yaml.version>
 
 		<!-- Java Advanced Imaging - https://java.net/projects/jai-core -->
@@ -5429,6 +5431,11 @@
 				<groupId>com.fasterxml.jackson.dataformat</groupId>
 				<artifactId>jackson-dataformat-cbor</artifactId>
 				<version>${com.fasterxml.jackson.dataformat.jackson-dataformat-cbor.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.dataformat</groupId>
+				<artifactId>jackson-dataformat-smile</artifactId>
+				<version>${com.fasterxml.jackson.dataformat.jackson-dataformat-smile.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/tests/generate-mega-melt.py
+++ b/tests/generate-mega-melt.py
@@ -31,6 +31,10 @@ ignoredArtifacts = [
     # because it has a module-info.java, so skip it until the
     # component collection is updated from Java 8 to Java 11.
     'ij',
+    # TEMP: The original ImageJ introduced changes in
+    # 1.54m/1.54n/1.54p that breaks some downstream tests.
+    # Disable them till we have time to address the issue.
+    'ij1-patcher', 'imagej-legacy',
     # NB: Skip artifacts requiring minimum Java version >8.
     'algart-tiff',
     # NB: The following artifacts have messy dependency trees.


### PR DESCRIPTION
Our plugin Mars uses Jackson a lot for basically all file storage. We use smile encoding to decrease the size of json files. Would it be possible to manage jackson-dataformat-smile in pom-scijava? This pull request adds it.

I noticed now the jackson jars are coming with Fiji, except for jackson-dataformat-smile. Also, this now created some version skew with our update site that is still at 2.11. I am in the process of fixing that and maybe I could just remove the Jackson jars from our update site. But then would it also be possible to add the jackson-dataformat-smile jar to Fiji? I know that adds more bloat

Already managing the version here would help.