### PR TITLE
Update to Bio-Formats 8.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1261,7 +1261,7 @@
 		<ome.jxrlib-all.version>${jxrlib-all.version}</ome.jxrlib-all.version>
 
 		<!-- Bio-Formats - https://github.com/ome/bioformats -->
-		<bio-formats.version>8.1.1</bio-formats.version>
+		<bio-formats.version>8.2.0</bio-formats.version>
 		<bio-formats-tools.version>${bio-formats.version}</bio-formats-tools.version>
 		<bio-formats_plugins.version>${bio-formats.version}</bio-formats_plugins.version>
 		<formats-api.version>${bio-formats.version}</formats-api.version>


### PR DESCRIPTION
See https://bio-formats.readthedocs.io/en/stable/about/whats-new.html#may.

The only dependency update was `sqlite-jdbc`, which is not defined separately here.