### PR TITLE
Update bigvolumeviewer: 0.3.4 -> 0.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1036,7 +1036,7 @@
 		<org.bigdataviewer.bigdataviewer-n5.version>${bigdataviewer-n5.version}</org.bigdataviewer.bigdataviewer-n5.version>
 
 		<!-- BigVolumeViewer - https://github.com/bigdataviewer/bigvolumeviewer-core -->
-		<bigvolumeviewer.version>0.3.4</bigvolumeviewer.version>
+		<bigvolumeviewer.version>0.4.1</bigvolumeviewer.version>
 		<sc.fiji.bigvolumeviewer.version>${bigvolumeviewer.version}</sc.fiji.bigvolumeviewer.version>
 
 		<!-- SPIM Data - https://github.com/bigdataviewer/spimdata -->


### PR DESCRIPTION
This needs a bit of testing.

The new `bigvolumeviewer-0.4.1` version added support for 8bit cached multi-resolution volumes (it was only 16bit before). Code changes are in this [branch](https://github.com/bigdataviewer/bigvolumeviewer-core/tree/8and16bit) and relevant discussion is in https://github.com/bigdataviewer/bigvolumeviewer-core/pull/16 and https://github.com/bigdataviewer/bigvolumeviewer-core/issues/25.

I suspect that this will break SciView, (via scenery). But probably it would be good to have this 8-bit support also for SciView, anyway. I suspect breakage because the shaders changed and there are new uniforms. scenery uses custom shaders, I think? So these would need to be updated, too.

I don't have time to dig into it myself at the moment... Is anyone interested in pushing this forward? @NicoKiaru @ekatrukha @kephale @skalarproduktraum 
