### PR TITLE
Update to Bio-Formats 8.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1279,11 +1279,11 @@
 		<com.zeroc.ice.version>${ice.version}</com.zeroc.ice.version>
 
 		<!-- OME Codecs - https://github.com/ome/ome-codecs -->
-		<ome-codecs.version>1.1.2</ome-codecs.version>
+		<ome-codecs.version>1.1.3</ome-codecs.version>
 		<org.openmicroscopy.ome-codecs.version>${ome-codecs.version}</org.openmicroscopy.ome-codecs.version>
 
 		<!-- OME Common Java - https://github.com/ome/ome-common-java -->
-		<ome-common.version>6.1.2</ome-common.version>
+		<ome-common.version>6.2.1</ome-common.version>
 		<org.openmicroscopy.ome-common.version>${ome-common.version}</org.openmicroscopy.ome-common.version>
 
 		<!-- Metakit - https://github.com/ome/ome-metakit -->
@@ -1295,7 +1295,7 @@
 		<org.openmicroscopy.ome-poi.version>${ome-poi.version}</org.openmicroscopy.ome-poi.version>
 
 		<!-- OME Model - https://github.com/ome/ome-model -->
-		<ome-model.version>6.5.1</ome-model.version>
+		<ome-model.version>6.5.3</ome-model.version>
 		<ome-xml.version>${ome-model.version}</ome-xml.version>
 		<specification.version>${ome-model.version}</specification.version>
 		<org.openmicroscopy.ome-xml.version>${ome-xml.version}</org.openmicroscopy.ome-xml.version>
@@ -1307,7 +1307,7 @@
 		<ome.jxrlib-all.version>${jxrlib-all.version}</ome.jxrlib-all.version>
 
 		<!-- Bio-Formats - https://github.com/ome/bioformats -->
-		<bio-formats.version>8.4.0</bio-formats.version>
+		<bio-formats.version>8.5.0</bio-formats.version>
 		<bio-formats-tools.version>${bio-formats.version}</bio-formats-tools.version>
 		<bio-formats_plugins.version>${bio-formats.version}</bio-formats_plugins.version>
 		<formats-api.version>${bio-formats.version}</formats-api.version>


### PR DESCRIPTION
Includes updates to other OME dependencies as indicated in https://github.com/ome/bioformats/releases/tag/v8.5.0. See also https://bio-formats.readthedocs.io/en/latest/about/whats-new.html#march.