### PR TITLE
update n5 component versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1195,7 +1195,7 @@
 		<org.janelia.saalfeldlab.n5-imglib2.version>${n5-imglib2.version}</org.janelia.saalfeldlab.n5-imglib2.version>
 
 		<!-- N5 Universe - https://github.com/saalfeldlab/n5-universe -->
-		<n5-universe.version>3.0.0</n5-universe.version>
+		<n5-universe.version>3.0.1</n5-universe.version>
 		<org.janelia.saalfeldlab.n5-universe.version>${n5-universe.version}</org.janelia.saalfeldlab.n5-universe.version>
 
 		<!-- N5 Viewer for Fiji - https://github.com/saalfeldlab/n5-viewer_fiji -->

--- a/pom.xml
+++ b/pom.xml
@@ -1167,7 +1167,7 @@
 		<net.imglib2.imglib2-label-multisets.version>${imglib2-label-multisets.version}</net.imglib2.imglib2-label-multisets.version>
 
 		<!-- N5 - https://github.com/saalfeldlab/n5 -->
-		<n5.version>4.0.0</n5.version>
+		<n5.version>4.0.1</n5.version>
 		<org.janelia.saalfeldlab.n5.version>${n5.version}</org.janelia.saalfeldlab.n5.version>
 
 		<!-- N5 AWS S3 - https://github.com/saalfeldlab/n5-aws-s3 -->

--- a/pom.xml
+++ b/pom.xml
@@ -1207,7 +1207,7 @@
 		<org.janelia.saalfeldlab.n5-zarr.version>${n5-zarr.version}</org.janelia.saalfeldlab.n5-zarr.version>
 
 		<!-- N5 ZStandard - https://github.com/JaneliaSciComp/n5-zstandard -->
-		<n5-zstandard.version>1.0.2</n5-zstandard.version>
+		<n5-zstandard.version>2.0.0</n5-zstandard.version>
 		<org.janelia.n5-zstandard.version>${n5-zstandard.version}</org.janelia.n5-zstandard.version>
 
 		<!-- Fiji-adjacent projects (available from ImageJ update sites) -->

--- a/pom.xml
+++ b/pom.xml
@@ -1167,43 +1167,43 @@
 		<net.imglib2.imglib2-label-multisets.version>${imglib2-label-multisets.version}</net.imglib2.imglib2-label-multisets.version>
 
 		<!-- N5 - https://github.com/saalfeldlab/n5 -->
-		<n5.version>3.5.1</n5.version>
+		<n5.version>4.0.0</n5.version>
 		<org.janelia.saalfeldlab.n5.version>${n5.version}</org.janelia.saalfeldlab.n5.version>
 
 		<!-- N5 AWS S3 - https://github.com/saalfeldlab/n5-aws-s3 -->
-		<n5-aws-s3.version>4.3.0</n5-aws-s3.version>
+		<n5-aws-s3.version>5.0.0</n5-aws-s3.version>
 		<org.janelia.saalfeldlab.n5-aws-s3.version>${n5-aws-s3.version}</org.janelia.saalfeldlab.n5-aws-s3.version>
 
 		<!-- N5 Blosc - https://github.com/saalfeldlab/n5-blosc -->
-		<n5-blosc.version>1.1.1</n5-blosc.version>
+		<n5-blosc.version>2.0.0</n5-blosc.version>
 		<org.janelia.saalfeldlab.n5-blosc.version>${n5-blosc.version}</org.janelia.saalfeldlab.n5-blosc.version>
 
 		<!-- N5 Google Cloud - https://github.com/saalfeldlab/n5-google-cloud -->
-		<n5-google-cloud.version>5.1.0</n5-google-cloud.version>
+		<n5-google-cloud.version>6.0.0</n5-google-cloud.version>
 		<org.janelia.saalfeldlab.n5-google-cloud.version>${n5-google-cloud.version}</org.janelia.saalfeldlab.n5-google-cloud.version>
 
 		<!-- N5 HDF5 Bindings - https://github.com/saalfeldlab/n5-hdf5 -->
-		<n5-hdf5.version>2.2.1</n5-hdf5.version>
+		<n5-hdf5.version>3.0.0</n5-hdf5.version>
 		<org.janelia.saalfeldlab.n5-hdf5.version>${n5-hdf5.version}</org.janelia.saalfeldlab.n5-hdf5.version>
 
 		<!-- N5 ImageJ Bindings - https://github.com/saalfeldlab/n5-ij -->
-		<n5-ij.version>4.4.1</n5-ij.version>
+		<n5-ij.version>5.0.0</n5-ij.version>
 		<org.janelia.saalfeldlab.n5-ij.version>${n5-ij.version}</org.janelia.saalfeldlab.n5-ij.version>
 
 		<!-- N5 ImgLib2 Bindings - https://github.com/saalfeldlab/n5-imglib2 -->
-		<n5-imglib2.version>7.0.2</n5-imglib2.version>
+		<n5-imglib2.version>8.0.0</n5-imglib2.version>
 		<org.janelia.saalfeldlab.n5-imglib2.version>${n5-imglib2.version}</org.janelia.saalfeldlab.n5-imglib2.version>
 
 		<!-- N5 Universe - https://github.com/saalfeldlab/n5-universe -->
-		<n5-universe.version>2.3.0</n5-universe.version>
+		<n5-universe.version>3.0.0</n5-universe.version>
 		<org.janelia.saalfeldlab.n5-universe.version>${n5-universe.version}</org.janelia.saalfeldlab.n5-universe.version>
 
 		<!-- N5 Viewer for Fiji - https://github.com/saalfeldlab/n5-viewer_fiji -->
-		<n5-viewer_fiji.version>6.1.2</n5-viewer_fiji.version>
+		<n5-viewer_fiji.version>6.2.0</n5-viewer_fiji.version>
 		<org.janelia.saalfeldlab.n5-viewer_fiji.version>${n5-viewer_fiji.version}</org.janelia.saalfeldlab.n5-viewer_fiji.version>
 
 		<!-- N5 Zarr - https://github.com/saalfeldlab/n5-zarr -->
-		<n5-zarr.version>1.5.1</n5-zarr.version>
+		<n5-zarr.version>2.0.0</n5-zarr.version>
 		<org.janelia.saalfeldlab.n5-zarr.version>${n5-zarr.version}</org.janelia.saalfeldlab.n5-zarr.version>
 
 		<!-- N5 ZStandard - https://github.com/JaneliaSciComp/n5-zstandard -->

--- a/pom.xml
+++ b/pom.xml
@@ -1041,7 +1041,7 @@
 		<jitk.jitk-tps.version>${jitk-tps.version}</jitk.jitk-tps.version>
 
 		<!-- BigWarp - https://github.com/saalfeldlab/bigwarp -->
-		<bigwarp.version>9.3.2</bigwarp.version>
+		<bigwarp.version>9.4.0</bigwarp.version>
 		<bigwarp_fiji.version>${bigwarp.version}</bigwarp_fiji.version>
 		<sc.fiji.bigwarp_fiji.version>${bigwarp_fiji.version}</sc.fiji.bigwarp_fiji.version>
 


### PR DESCRIPTION
Leaving this as a draft for now, because some artifacts depending on n5 will need updating

PRs are open for some of them:

* [bigwarp](https://github.com/saalfeldlab/bigwarp/pull/190)
* [bigdataviewer-core](https://github.com/bigdataviewer/bigdataviewer-core/pull/220)
* [bigdataviewer-n5](https://github.com/bigdataviewer/bigdataviewer-n5/pull/4)


## Details

* n5-4.0.0
* n5-aws-s3-5.0.0
* n5-blosc-2.0.0
* n5-google-cloud-6.0.0
* n5-hdf5-3.0.0
* n5-ij-5.0.0
* n5-imglib2-8.0.0
* n5-universe-3.0.0
* n5-zarr-2.0.0
* n5-zstandard-2.0.0