### PR TITLE
BoneJ 7.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1244,7 +1244,7 @@
 		<net.preibisch.multiview-simulation.version>${multiview-simulation.version}</net.preibisch.multiview-simulation.version>
 
 		<!-- BoneJ - https://imagej.net/plugins/bonej -->
-		<bonej.version>7.1.10</bonej.version>
+		<bonej.version>7.2.0</bonej.version>
 		<bonej-plugins.version>${bonej.version}</bonej-plugins.version>
 		<bonej-ops.version>${bonej.version}</bonej-ops.version>
 		<bonej-legacy-plugins_.version>${bonej.version}</bonej-legacy-plugins_.version>


### PR DESCRIPTION
Harmonise BoneJ plugins (Legacy, Modern, Plus) to use `Dataset` for image IO and `SharedTable` for numeric results. The intention is to make a consistent API for Python script users.