### PR TITLE
Bump multiview-reconstruction 9.0.11, BigStitcher 3.0.8, Descriptor_based_registration 3.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -777,7 +777,7 @@
 		<Correct_3D_Drift.version>1.0.7</Correct_3D_Drift.version>
 		<sc.fiji.Correct_3D_Drift.version>${Correct_3D_Drift.version}</sc.fiji.Correct_3D_Drift.version>
 
-		<Descriptor_based_registration.version>3.0.2</Descriptor_based_registration.version>
+		<Descriptor_based_registration.version>3.0.3</Descriptor_based_registration.version>
 		<sc.fiji.Descriptor_based_registration.version>${Descriptor_based_registration.version}</sc.fiji.Descriptor_based_registration.version>
 
 		<Dichromacy.version>2.1.2</Dichromacy.version>
@@ -1237,8 +1237,8 @@
 		<net.haesleinhuepf.clijx-weka_.version>${clijx-weka_.version}</net.haesleinhuepf.clijx-weka_.version>
 
 		<!-- BigStitcher - https://imagej.net/plugins/bigstitcher -->
-		<BigStitcher.version>3.0.7</BigStitcher.version>
-		<multiview-reconstruction.version>9.0.9</multiview-reconstruction.version>
+		<BigStitcher.version>3.0.8</BigStitcher.version>
+		<multiview-reconstruction.version>9.0.11</multiview-reconstruction.version>
 		<multiview-simulation.version>0.3.1</multiview-simulation.version>
 		<net.preibisch.BigStitcher.version>${BigStitcher.version}</net.preibisch.BigStitcher.version>
 		<net.preibisch.multiview-reconstruction.version>${multiview-reconstruction.version}</net.preibisch.multiview-reconstruction.version>


### PR DESCRIPTION
Update Preibisch ecosystem artifacts:
- multiview-reconstruction 9.0.9 → 9.0.11
- BigStitcher 3.0.7 → 3.0.8 (uses MVR 9.0.11)
- Descriptor_based_registration 3.0.2 → 3.0.3 (uses MVR 9.0.11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)