### PR TITLE
Revert "Purge opencensus libraries from the BOM"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5366,15 +5366,6 @@
 				<groupId>com.google.api</groupId>
 				<artifactId>gax</artifactId>
 				<version>${com.google.api.gax.version}</version>
-				<exclusions>
-					<!--
-					Analytics libraries for collecting and transmitting app metrics.
-					-->
-					<exclusion>
-						<groupId>io.opencensus</groupId>
-						<artifactId>*</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>com.google.api</groupId>
@@ -5436,15 +5427,6 @@
 				<groupId>com.google.cloud</groupId>
 				<artifactId>google-cloud-core-http</artifactId>
 				<version>${com.google.cloud.google-cloud-core-http.version}</version>
-				<exclusions>
-					<!--
-					Analytics libraries for collecting and transmitting app metrics.
-					-->
-					<exclusion>
-						<groupId>io.opencensus</groupId>
-						<artifactId>*</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>com.google.cloud</groupId>
@@ -5455,29 +5437,11 @@
 				<groupId>com.google.cloud</groupId>
 				<artifactId>google-cloud-resourcemanager</artifactId>
 				<version>${com.google.cloud.google-cloud-resourcemanager.version}</version>
-				<exclusions>
-					<!--
-					Analytics libraries for collecting and transmitting app metrics.
-					-->
-					<exclusion>
-						<groupId>io.opencensus</groupId>
-						<artifactId>*</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>com.google.cloud</groupId>
 				<artifactId>google-cloud-storage</artifactId>
 				<version>${com.google.cloud.google-cloud-storage.version}</version>
-				<exclusions>
-					<!--
-					Analytics libraries for collecting and transmitting app metrics.
-					-->
-					<exclusion>
-						<groupId>io.opencensus</groupId>
-						<artifactId>*</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 
 			<!-- Google HTTP Client - https://github.com/googleapis/google-http-java-client -->
@@ -5485,15 +5449,6 @@
 				<groupId>com.google.http-client</groupId>
 				<artifactId>google-http-client</artifactId>
 				<version>${com.google.http-client.google-http-client.version}</version>
-				<exclusions>
-					<!--
-					Analytics libraries for collecting and transmitting app metrics.
-					-->
-					<exclusion>
-						<groupId>io.opencensus</groupId>
-						<artifactId>*</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>com.google.http-client</groupId>


### PR DESCRIPTION
This reverts commit 7a2c1b3f93d4558b481da360b275ca337219f10c.

It was [previously recognized ](https://forum.image.sc/t/opencensus-contrib-http-util/110087/3)that excluding io.opencensus broke `n5-google-cloud`. This was[ reverted in Fiji](https://github.com/saalfeldlab/n5-google-cloud/issues/38#issuecomment-4454750805), but not in `pom-scijava`. As such, upgrading `n5-universe` or `n5-google-cloud` to `45.0.0` currently fails with the following style of errors:

> Error:  org.janelia.saalfeldlab.n5.universe.storage.zarr.zarr3.Zarr3GoogleCloudFactoryTest$ZarrGoogleCloudMockTest.testWriteReadIntBlock
Error:    Run 1: Zarr3GoogleCloudFactoryTest$ZarrGoogleCloudMockTest.<init>:64 » NoClassDefFound io/opencensus/trace/propagation/TextFormat$Setter

`44.0.0` still works as expected. 

